### PR TITLE
Cookie policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
   <script src="https://unpkg.com/docsify-themeable"></script>
   <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
   <script type="text/javascript" src="/zxtm/piwik2.js"></script>
+
+  <link rel='stylesheet' id='simple-cookie-css' href="/wp-content/plugins/wordpress-simple-cookie-plugin/cookies-min.css" type='text/css' media='' />
+  <meta name="simplecookie_policy" content="/policies/cookies/" />
+  <script type='text/javascript' src='/wp-content/plugins/wordpress-simple-cookie-plugin/cookies-gcc.js' id='simple-cookie-js'></script>
 </body>
 <style>
   .videoWrapper {


### PR DESCRIPTION
For any tracking of websites (using piwik/matomo), there must be an associated cookie policy banner as documented [here](https://ssg-confluence.internal.sanger.ac.uk/display/WEB/Cookie+policy+and+preferences)

FYI @kumarnaren @KMellor 

I will merge and deploy (without review) but keep this branch for future reference.