### PR TITLE
Set tracking script for single-page view

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,13 @@
   <script src="https://unpkg.com/docsify-themeable"></script>
   <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
   <script type="text/javascript" src="/zxtm/piwik2.js"></script>
+  <script>
+      window.addEventListener('hashchange', function() {
+        _paq.push(['setCustomUrl', '/F2/']);
+        _paq.push(['setDocumentTitle', 'F2 Training']);
+        _paq.push(['trackPageView']);
+      });
+  </script>
 
   <link rel='stylesheet' id='simple-cookie-css' href="https://www.sanger.ac.uk/wp-content/plugins/wordpress-simple-cookie-plugin/cookies-min.css" type='text/css' media='' />
   <meta name="simplecookie_policy" content="/policies/cookies/" />


### PR DESCRIPTION
Added a script to track the F2 page. It should work using a direct link to F2, but the collaborator has to accept the cookies and also refresh or go onto another page in F2 (eg. Introduction) because the tracker doesn't catch it the first time they land on that page.
