### PR TITLE
separate permission to deploy code to server from permission to deploy a new version of the web site

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Try to avoid embedding HTML in the markdown files if possible.
 ### References
 All references, in links and images, should be relative to the project root, eg. `/F1/microreact.md`.
 
-## Deploying live website
+## Deploying website update script
+
+The live website is updated with the `docker_deploy.sh` script.  If this has been changed (or if in doubt) deplot it to the server.
+
+```
+./deploy.sh <remote user> <deployment host address>
+```
+
+## Updating live website
 1. If the last commit hasn't been tagged, tag the repo following versioning convention in current tags e.g. `v0.1.13`
 
 2. Build image using tag version (without the v e.g. `0.1.13`). The `<docker user>` must be the name of the docker repository you plan to use
@@ -36,5 +44,5 @@ docker push <docker user>/bactgen-training-app:<version>
 You must have ssh access to the host address. If you do not then the recent contributors of this repo that still work at the Sanger should already have access. You can ask them to add your public ssh key. Additional information on remote users and host addresses can be found [here](http://mediawiki.internal.sanger.ac.uk/index.php/Websites_managed_for_team_284_(Stephen_Bentley%27s_group)).
 
 ```
-./deploy.sh <version> <remote user> <deployment host address> <docker user>
+ssh <remote user>@<deployment host address> docker_deploy.sh <version> <docker user>
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All references, in links and images, should be relative to the project root, eg.
 
 ## Deploying website update script
 
-The live website is updated with the `docker_deploy.sh` script.  If this has been changed (or if in doubt) deplot it to the server.
+The live website is updated with the `docker_deploy.sh` script.  If this has been changed (or if in doubt) deploy it to the server.
 
 ```
 ./deploy.sh <remote user> <deployment host address>

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,44 +3,29 @@
 # Deploy a release of the Bactgen training app.
 
 # check args count
-if [ $# -ne 4 ]; then
-  echo "Usage: $0 <version> <remote user> <deployment host address> <docker user>"
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <remote user> <deployment host address>"
   exit 1
 fi
 
-VERSION=$1
-REMOTE_USER=$2
-REMOTE_HOST=$3
-APP=bactgen-training-app
-DOCKER_USER=$4
-IMAGE_URL=${DOCKER_USER}/${APP}
-EXPOSED_PORT=8000
+REMOTE_USER=$1
+REMOTE_HOST=$2
+
+echo "Copying docker-deploy.sh to ${REMOTE_USER}@${REMOTE_HOST}"
+scp -o ControlPath=%C docker_deploy.sh $REMOTE_USER@$REMOTE_HOST:~/docker_deploy.sh
+
 
 # Replace the running version
 ssh -o ControlMaster=yes \
     -o ControlPersist=yes \
     -o ControlPath=%C $REMOTE_USER@$REMOTE_HOST << EOF
 
-    echo "Stopping running ${APP} docker container..."
-    docker stop ${APP}
-    docker rm ${APP}
-    echo "Container stopped"
-
-    docker pull ${IMAGE_URL}:${VERSION}
-    if [[ $? -eq 0 ]]
-    then
-      echo "Starting ${APP}..."
-      docker run -d -p ${EXPOSED_PORT}:80 -p 80:80 --name ${APP} --security-opt=no-new-privileges:true --cap-drop=ALL --cap-add=CHOWN --cap-add=NET_BIND_SERVICE --cap-add=SETUID --cap-add=SETGID --cap-add=FOWNER --restart=unless-stopped ${IMAGE_URL}:${VERSION}
-      if [[ $? -ne 0 ]]
-      then
-        echo "ERROR: Failed to start ${APP} docker container"
-      fi
-    else
-      echo "ERROR: Failed to pull specified ${APP} image version"
-    fi
-
-    echo "Done."
+    echo "Setting file permissions on server"
+    chmod +x docker_deploy.sh
+    chmod go-rwx docker_deploy.sh
 EOF
 
 # close the connection
 ssh -o ControlPath=%C -O exit $REMOTE_USER@$REMOTE_HOST
+
+echo "Done."

--- a/docker_deploy.sh
+++ b/docker_deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Deploy a release of the Bactgen training app.
+
+# check args count
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <version> <docker user>"
+  exit 1
+fi
+
+# if executed by ssh the script name may appear as first arg: ignore it
+if [[ "$1" =~ $(basename $0) ]]; then
+  shift
+fi
+
+VERSION=$1
+DOCKER_USER=$2
+
+APP=bactgen-training-app
+IMAGE_URL=${DOCKER_USER}/${APP}
+EXPOSED_PORT=8000
+
+# Replace the running version
+
+echo "Stopping running ${APP} docker container..."
+docker stop ${APP}
+docker rm ${APP}
+echo "Container stopped"
+
+docker pull ${IMAGE_URL}:${VERSION}
+if [[ $? -eq 0 ]]
+then
+    echo "Starting ${APP}..."
+    docker run -d -p ${EXPOSED_PORT}:80 -p 80:80 --name ${APP} --security-opt=no-new-privileges:true --cap-drop=ALL --cap-add=CHOWN --cap-add=NET_BIND_SERVICE --cap-add=SETUID --cap-add=SETGID --cap-add=FOWNER --restart=unless-stopped ${IMAGE_URL}:${VERSION}
+    if [[ $? -ne 0 ]]
+    then
+    echo "ERROR: Failed to start ${APP} docker container"
+    fi
+else
+    echo "ERROR: Failed to pull specified ${APP} image version"
+fi
+
+echo "Done."


### PR DESCRIPTION
- adds new script `docker_deploy.sh` that deploys the docker image (essentailly the same a the old `deploy.sh` but to be run on the server, not locally by a developer)
- replaces `deploy.sh` with script that copies `docker_deploy.sh` to the server
Updating the web site, when there is a new docker image, involves running `docker_deploy.sh` only -- but this must now be done via ssh. The `deploy.sh` script is needed only if `docker_deploy.sh` has been modified.

Disadvantages:
- deployment is a two-step process (ubnless only the docker image has been updated, in which case it remains a single step)

Advantages:
- updating the website can be done by users without full access to the server